### PR TITLE
Update README.md

### DIFF
--- a/pythonProjects/api-reader/README.md
+++ b/pythonProjects/api-reader/README.md
@@ -8,7 +8,7 @@ hatch new "api-reader"
 
 # Enter into the created directory of api-reader: use this command in terminal -> cd api-reader
 # Second Command
-python -m venv venv
+python -m venv venv (or) use: py -m venv venv
 # This sets up a venv for using python libraries
 
 # Third Command


### PR DESCRIPTION
Added "(or) use: py -m venv venv" at Line 11 since "py -m venv venv" isn't working.